### PR TITLE
fix: Fixes #6 to support Edgeware

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "bootstrap": "^4.5.0",
+    "edgeware-node-types": "^2.3.3",
     "express": "^4.17.1",
     "jquery": "^3.5.1",
     "p5": "^1.0.0",

--- a/src/Game.js
+++ b/src/Game.js
@@ -129,7 +129,7 @@ class Game extends Component {
       const [signedBlock] = await Promise.all([
         api.rpc.chain.getBlock(blockHash)
       ]);
-      console.log('signedBlock', signedBlock);
+      // console.log('signedBlock', signedBlock);
       console.log('signedBlock', signedBlock.block.header.parentHash.toHex());
 
       // // Hash for each extrinsic in the block

--- a/src/Game.js
+++ b/src/Game.js
@@ -140,17 +140,6 @@ class Game extends Component {
       //   // console.log('Hash for extrinsic in the block', index, u8aToString(bufferToU8a(ex.data)));
       // });
 
-      let [currentBlockEvents] = [];
-      if (currentEndpointName !== 'Edgeware Mainnet') {
-        [currentBlockEvents] = await Promise.all([
-          api.query.system.events.at(currentBlockHash) 
-        ]);
-        // console.log('currentBlockEvents', currentBlockEvents);
-        if (currentBlockEvents.length) {
-          console.log(`\nReceived ${currentBlockEvents.length} events:`);
-        }
-      }
-
       // Digest of current block
       const [currentDigest] = await Promise.all([
         api.query.system.digest() 
@@ -181,6 +170,15 @@ class Game extends Component {
       // Only update the newActiveAccountIds if we're not using Edgeware
       // until this issue is resolved: https://github.com/hicommonwealth/edgeware-node/issues/176
       if (currentEndpointName !== 'Edgeware Mainnet') {
+        let [currentBlockEvents] = [];
+        [currentBlockEvents] = await Promise.all([
+          api.query.system.events.at(currentBlockHash) 
+        ]);
+        // console.log('currentBlockEvents', currentBlockEvents);
+        if (currentBlockEvents.length) {
+          console.log(`\nReceived ${currentBlockEvents.length} events:`);
+        }
+
         let foundAccountIds = {};
         currentBlockEvents.forEach((record) => {
           const { event, phase } = record;

--- a/src/Game.js
+++ b/src/Game.js
@@ -88,9 +88,8 @@ class Game extends Component {
     const keyring = new Keyring({ type: 'sr25519' });
     const types = Object.values(edgewareDefinitions).reduce((res, { types }) => ({ ...res, ...types }), {});
     let api
-    if (currentEndpointName === 'Edgware Mainnet') {
-      api = await ApiPromise.create({ provider });
-    } else {
+    if (currentEndpointName === 'Edgeware Mainnet') {
+      console.log('Setting up Edgeware');
       api = await ApiPromise.create({
         provider,
         // Reference: https://www.npmjs.com/package/edgeware-node-types#usage
@@ -109,6 +108,8 @@ class Game extends Component {
         // override duplicate type name
         typesAlias: { voting: { Tally: 'VotingTally' } },
       });
+    } else {
+      api = await ApiPromise.create({ provider });
     }
     const [chain, nodeName, nodeVersion] = await Promise.all([
       api.rpc.system.chain(),

--- a/src/Game.js
+++ b/src/Game.js
@@ -81,7 +81,7 @@ class Game extends Component {
     // // assuming one of the keys in `allProviders` is 'kusama-cc3', we can then use that provider
     // const { provider } = web3UseRpcProvider('polkadot-js', 'kusama-cc3');
 
-    const currentEndpoint = customEndpoint || ENDPOINTS['Kusama'];
+    const currentEndpoint = customEndpoint || ENDPOINTS['Edgeware Mainnet'];
     const currentEndpointName = Object.keys(ENDPOINTS)[Object.values(ENDPOINTS).indexOf(currentEndpoint)];
     const provider = new WsProvider(currentEndpoint);
     // Create a keyring instance. https://polkadot.js.org/api/start/keyring.html

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,15 +1,15 @@
 const ENDPOINTS = {
   'Kusama': 'wss://cc3-5.kusama.network/',
   'Polkadot-CC1': 'wss://cc1-1.polkadot.network',
+  // Note: Edgeware not supported as it returns error
+  // `Unhandled Rejection (Error): createType(Vec<EventRecord>):: Struct: failed on 'data':: Unable to create Enum via index 20, in Normal, Operational, Mandatory`
+  'Edgeware Mainnet': 'wss://mainnet1.edgewa.re',
   'DataHighway Harbour Testnet': 'wss://testnet-harbour.datahighway.com',
   // Note: Westend not supported as it does not use Treasury, which is required for using Tips
   'Westend Testnet': 'wss://westend-rpc.polkadot.io',
   // Note: Kulupu not supported as it returns error
   // `Unhandled Rejection (TypeError): Cannot read property 'validators' of undefined`
   // 'Kulupu Mainnet': 'wss://rpc.kulupu.network/ws',
-  // Note: Edgeware not supported as it returns error
-  // `Unhandled Rejection (Error): createType(Vec<EventRecord>):: Struct: failed on 'data':: Unable to create Enum via index 20, in Normal, Operational, Mandatory`
-  // 'Edgeware Mainnet': 'wss://mainnet1.edgewa.re'
 }
 
 const COLOURS = {

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,8 +1,6 @@
 const ENDPOINTS = {
   'Kusama': 'wss://cc3-5.kusama.network/',
   'Polkadot-CC1': 'wss://cc1-1.polkadot.network',
-  // Note: Edgeware not supported as it returns error
-  // `Unhandled Rejection (Error): createType(Vec<EventRecord>):: Struct: failed on 'data':: Unable to create Enum via index 20, in Normal, Operational, Mandatory`
   'Edgeware Mainnet': 'wss://mainnet1.edgewa.re',
   'DataHighway Harbour Testnet': 'wss://testnet-harbour.datahighway.com',
   // Note: Westend not supported as it does not use Treasury, which is required for using Tips

--- a/yarn.lock
+++ b/yarn.lock
@@ -4106,6 +4106,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+edgeware-node-types@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/edgeware-node-types/-/edgeware-node-types-2.3.3.tgz#d062377a9936da0ac4cc2e9c7b179ebc5a46157f"
+  integrity sha512-sucK/kpAaKqFS/Q67qQ5/LEPDykFFiT+InGbM0TDHhPitQ87OkbAhQqyacnIXPy0+LZk1E52wIq7DLAQg6hIOA==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"


### PR DESCRIPTION
Exclude code that uses `api.query.system.events.at(currentBlockHash)` as it was causing error when using Edgeware, and that part of the code wasn't necessary for the game anyway